### PR TITLE
dartfmt all the code.

### DIFF
--- a/benchmark/eval.dart
+++ b/benchmark/eval.dart
@@ -30,7 +30,6 @@ class EvalBenchmark extends BenchmarkBase {
   run() {
     var value = eval(expr, scope);
   }
-
 }
 
 double total = 0.0;
@@ -43,17 +42,15 @@ benchmark(String name, String expr, {Object model, Map variables}) {
 }
 
 main() {
-
   benchmark('Constant', '1');
   benchmark('Top-level Name', 'foo',
       variables: {'foo': new Foo(new Bar('hello'))});
-  benchmark('Model field', 'bar',
-      model: new Foo(new Bar('hello')));
+  benchmark('Model field', 'bar', model: new Foo(new Bar('hello')));
   benchmark('Path', 'foo.bar.baz',
       variables: {'foo': new Foo(new Bar('hello'))});
-  benchmark('Map', 'm["foo"]',
-      variables: {'m': {'foo': 1}});
+  benchmark('Map', 'm["foo"]', variables: {
+    'm': {'foo': 1}
+  });
   benchmark('Equality', '"abc" == "123"');
   print('total: $total us');
-
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -28,8 +28,8 @@ main() {
   };
 
   templateBind(querySelector('#test'))
-      ..bindingDelegate = new PolymerExpressions(globals: globals)
-      ..model = john;
+    ..bindingDelegate = new PolymerExpressions(globals: globals)
+    ..model = john;
 
   templateBind(querySelector('#test2')).model = john;
 }

--- a/lib/async.dart
+++ b/lib/async.dart
@@ -11,7 +11,8 @@ class StreamBinding<T> extends ObservableBox {
   final Stream<T> stream;
 
   StreamBinding(this.stream) {
-    stream.listen((T i) { value = i; });
+    stream.listen((T i) {
+      value = i;
+    });
   }
-
 }

--- a/lib/eval.dart
+++ b/lib/eval.dart
@@ -16,33 +16,29 @@ import 'filter.dart';
 import 'visitor.dart';
 
 final _BINARY_OPERATORS = {
-  '+':   (a, b) => a + b,
-  '-':   (a, b) => a - b,
-  '*':   (a, b) => a * b,
-  '/':   (a, b) => a / b,
-  '%':   (a, b) => a % b,
-  '==':  (a, b) => a == b,
-  '!=':  (a, b) => a != b,
+  '+': (a, b) => a + b,
+  '-': (a, b) => a - b,
+  '*': (a, b) => a * b,
+  '/': (a, b) => a / b,
+  '%': (a, b) => a % b,
+  '==': (a, b) => a == b,
+  '!=': (a, b) => a != b,
   '===': (a, b) => identical(a, b),
   '!==': (a, b) => !identical(a, b),
-  '>':   (a, b) => a > b,
-  '>=':  (a, b) => a >= b,
-  '<':   (a, b) => a < b,
-  '<=':  (a, b) => a <= b,
-  '||':  (a, b) => a || b,
-  '&&':  (a, b) => a && b,
-  '|':   (a, f) {
+  '>': (a, b) => a > b,
+  '>=': (a, b) => a >= b,
+  '<': (a, b) => a < b,
+  '<=': (a, b) => a <= b,
+  '||': (a, b) => a || b,
+  '&&': (a, b) => a && b,
+  '|': (a, f) {
     if (f is Transformer) return f.forward(a);
     if (f is Filter) return f(a);
     throw new EvalException("Filters must be a one-argument function.");
   }
 };
 
-final _UNARY_OPERATORS = {
-  '+': (a) => a,
-  '-': (a) => -a,
-  '!': (a) => !a,
-};
+final _UNARY_OPERATORS = {'+': (a) => a, '-': (a) => -a, '!': (a) => !a,};
 
 final _BOOLEAN_OPERATORS = ['!', '||', '&&'];
 
@@ -81,7 +77,6 @@ Object update(ExpressionObserver expr, Scope scope, {skipChanges: false}) {
  */
 Object assign(Expression expr, Object value, Scope scope,
     {bool checkAssignability: true}) {
-
   Expression expression;
   var property;
   bool isIndex = false;
@@ -141,7 +136,6 @@ Object assign(Expression expr, Object value, Scope scope,
   return value;
 }
 
-
 /**
  * A scope in polymer expressions that can map names to objects. Scopes contain
  * a set of named variables and a unique model object. The scope structure
@@ -155,7 +149,8 @@ abstract class Scope implements Indexable<String, Object> {
   /** Create a scope containing a [model] and all of [variables]. */
   factory Scope({Object model, Map<String, Object> variables}) {
     var scope = new _ModelScope(model);
-    return variables == null ? scope
+    return variables == null
+        ? scope
         : new _GlobalsScope(new Map<String, Object>.from(variables), scope);
   }
 
@@ -196,7 +191,7 @@ class _ModelScope extends Scope {
 
   _ModelScope(this.model) : super._();
 
-  Object operator[](String name) {
+  Object operator [](String name) {
     if (name == 'this') return model;
     var symbol = smoke.nameToSymbol(name);
     if (model == null || symbol == null) {
@@ -229,7 +224,7 @@ class _LocalVariableScope extends Scope {
 
   Object get model => parent != null ? parent.model : null;
 
-  Object operator[](String name) {
+  Object operator [](String name) {
     if (varName == name) return _convert(value);
     if (parent != null) return parent[name];
     throw new EvalException("variable '$name' not found");
@@ -256,7 +251,7 @@ class _GlobalsScope extends Scope {
 
   Object get model => parent != null ? parent.model : null;
 
-  Object operator[](String name) {
+  Object operator [](String name) {
     if (variables.containsKey(name)) return _convert(variables[name]);
     if (parent != null) return parent[name];
     throw new EvalException("variable '$name' not found");
@@ -456,7 +451,7 @@ class ObserverBuilder extends Visitor {
   visitIndex(Index i) {
     var receiver = visit(i.receiver);
     var arg = visit(i.argument);
-    var index =  new IndexObserver(i, receiver, arg);
+    var index = new IndexObserver(i, receiver, arg);
     receiver._parent = index;
     arg._parent = index;
     return index;
@@ -467,7 +462,7 @@ class ObserverBuilder extends Visitor {
     var args = (i.arguments == null)
         ? null
         : i.arguments.map(visit).toList(growable: false);
-    var invoke =  new InvokeObserver(i, receiver, args);
+    var invoke = new InvokeObserver(i, receiver, args);
     receiver._parent = invoke;
     if (args != null) args.forEach((a) => a._parent = invoke);
     return invoke;
@@ -538,7 +533,6 @@ class ObserverBuilder extends Visitor {
 
 class EmptyObserver extends ExpressionObserver<EmptyExpression>
     implements EmptyExpression {
-
   EmptyObserver(EmptyExpression value) : super(value);
 
   _updateSelf(Scope scope) {
@@ -550,7 +544,6 @@ class EmptyObserver extends ExpressionObserver<EmptyExpression>
 }
 
 class LiteralObserver extends ExpressionObserver<Literal> implements Literal {
-
   LiteralObserver(Literal value) : super(value);
 
   dynamic get value => _expr.value;
@@ -564,7 +557,6 @@ class LiteralObserver extends ExpressionObserver<Literal> implements Literal {
 
 class ListLiteralObserver extends ExpressionObserver<ListLiteral>
     implements ListLiteral {
-
   final List<ExpressionObserver> items;
 
   ListLiteralObserver(ListLiteral value, this.items) : super(value);
@@ -578,14 +570,13 @@ class ListLiteralObserver extends ExpressionObserver<ListLiteral>
 
 class MapLiteralObserver extends ExpressionObserver<MapLiteral>
     implements MapLiteral {
-
   final List<MapLiteralEntryObserver> entries;
 
   MapLiteralObserver(MapLiteral value, this.entries) : super(value);
 
   _updateSelf(Scope scope) {
-    _value = entries.fold(new Map(),
-        (m, e) => m..[e.key._value] = e.entryValue._value);
+    _value = entries.fold(
+        new Map(), (m, e) => m..[e.key._value] = e.entryValue._value);
   }
 
   accept(Visitor v) => v.visitMapLiteral(this);
@@ -593,7 +584,6 @@ class MapLiteralObserver extends ExpressionObserver<MapLiteral>
 
 class MapLiteralEntryObserver extends ExpressionObserver<MapLiteralEntry>
     implements MapLiteralEntry {
-
   final LiteralObserver key;
   final ExpressionObserver entryValue;
 
@@ -605,7 +595,6 @@ class MapLiteralEntryObserver extends ExpressionObserver<MapLiteralEntry>
 
 class IdentifierObserver extends ExpressionObserver<Identifier>
     implements Identifier {
-
   IdentifierObserver(Identifier value) : super(value);
 
   String get value => _expr.value;
@@ -631,7 +620,6 @@ class ParenthesizedObserver extends ExpressionObserver<ParenthesizedExpression>
   final ExpressionObserver child;
 
   ParenthesizedObserver(ParenthesizedExpression expr, this.child) : super(expr);
-
 
   _updateSelf(Scope scope) {
     _value = child._value;
@@ -662,12 +650,10 @@ class UnaryObserver extends ExpressionObserver<UnaryOperator>
 
 class BinaryObserver extends ExpressionObserver<BinaryOperator>
     implements BinaryOperator {
-
   final ExpressionObserver left;
   final ExpressionObserver right;
 
-  BinaryObserver(BinaryOperator expr, this.left, this.right)
-      : super(expr);
+  BinaryObserver(BinaryOperator expr, this.left, this.right) : super(expr);
 
   String get operator => _expr.operator;
 
@@ -681,7 +667,8 @@ class BinaryObserver extends ExpressionObserver<BinaryOperator>
       _value = null;
     } else {
       if (operator == '|' && left._value is ObservableList) {
-        _subscription = (left._value as ObservableList).listChanges
+        _subscription = (left._value as ObservableList)
+            .listChanges
             .listen((_) => _invalidate(scope));
       }
       _value = f(left._value, right._value);
@@ -689,25 +676,23 @@ class BinaryObserver extends ExpressionObserver<BinaryOperator>
   }
 
   accept(Visitor v) => v.visitBinaryOperator(this);
-
 }
 
 class TernaryObserver extends ExpressionObserver<TernaryOperator>
     implements TernaryOperator {
-
   final ExpressionObserver condition;
   final ExpressionObserver trueExpr;
   final ExpressionObserver falseExpr;
 
-  TernaryObserver(TernaryOperator expr, this.condition, this.trueExpr,
-      this.falseExpr) : super(expr);
+  TernaryObserver(
+      TernaryOperator expr, this.condition, this.trueExpr, this.falseExpr)
+      : super(expr);
 
   _updateSelf(Scope scope) {
     _value = _toBool(condition._value) ? trueExpr._value : falseExpr._value;
   }
 
   accept(Visitor v) => v.visitTernaryOperator(this);
-
 }
 
 class GetterObserver extends ExpressionObserver<Getter> implements Getter {
@@ -754,8 +739,8 @@ class IndexObserver extends ExpressionObserver<Index> implements Index {
     _value = receiverValue[key];
 
     if (receiverValue is ObservableList) {
-      _subscription = (receiverValue as ObservableList).listChanges
-          .listen((changes) {
+      _subscription =
+          (receiverValue as ObservableList).listChanges.listen((changes) {
         if (changes.any((c) => c.indexChanged(key))) _invalidate(scope);
       });
     } else if (receiverValue is Observable) {
@@ -774,8 +759,7 @@ class InvokeObserver extends ExpressionObserver<Invoke> implements Invoke {
   final ExpressionObserver receiver;
   final List<ExpressionObserver> arguments;
 
-  InvokeObserver(Expression expr, this.receiver, this.arguments)
-      : super(expr) {
+  InvokeObserver(Expression expr, this.receiver, this.arguments) : super(expr) {
     assert(arguments != null);
   }
 
@@ -800,13 +784,14 @@ class InvokeObserver extends ExpressionObserver<Invoke> implements Invoke {
       _value = smoke.invoke(receiverValue, symbol, args);
 
       if (receiverValue is Observable) {
-        _subscription = (receiverValue as Observable).changes.listen(
-            (List<ChangeRecord> changes) {
-              if (changes.any(
-                  (c) => c is PropertyChangeRecord && c.name == symbol)) {
-                _invalidate(scope);
-              }
-            });
+        _subscription = (receiverValue as Observable)
+            .changes
+            .listen((List<ChangeRecord> changes) {
+          if (changes
+              .any((c) => c is PropertyChangeRecord && c.name == symbol)) {
+            _invalidate(scope);
+          }
+        });
       }
     }
   }

--- a/lib/expression.dart
+++ b/lib/expression.dart
@@ -132,8 +132,8 @@ class MapLiteralEntry extends Expression {
 
   String toString() => "$key: $entryValue";
 
-  bool operator ==(o) => o is MapLiteralEntry && o.key == key
-      && o.entryValue == entryValue;
+  bool operator ==(o) =>
+      o is MapLiteralEntry && o.key == key && o.entryValue == entryValue;
 
   int get hashCode => _JenkinsSmiHash.hash2(key.hashCode, entryValue.hashCode);
 }
@@ -176,8 +176,8 @@ class UnaryOperator extends Expression {
 
   String toString() => '$operator $child';
 
-  bool operator ==(o) => o is UnaryOperator && o.operator == operator
-      && o.child == child;
+  bool operator ==(o) =>
+      o is UnaryOperator && o.operator == operator && o.child == child;
 
   int get hashCode => _JenkinsSmiHash.hash2(operator.hashCode, child.hashCode);
 }
@@ -193,11 +193,14 @@ class BinaryOperator extends Expression {
 
   String toString() => '($left $operator $right)';
 
-  bool operator ==(o) => o is BinaryOperator && o.operator == operator
-      && o.left == left && o.right == right;
+  bool operator ==(o) =>
+      o is BinaryOperator &&
+      o.operator == operator &&
+      o.left == left &&
+      o.right == right;
 
-  int get hashCode => _JenkinsSmiHash.hash3(operator.hashCode, left.hashCode,
-      right.hashCode);
+  int get hashCode =>
+      _JenkinsSmiHash.hash3(operator.hashCode, left.hashCode, right.hashCode);
 }
 
 class TernaryOperator extends Expression {
@@ -211,13 +214,14 @@ class TernaryOperator extends Expression {
 
   String toString() => '($condition ? $trueExpr : $falseExpr)';
 
-  bool operator ==(o) => o is TernaryOperator
-      && o.condition == condition
-      && o.trueExpr == trueExpr
-      && o.falseExpr == falseExpr;
+  bool operator ==(o) =>
+      o is TernaryOperator &&
+      o.condition == condition &&
+      o.trueExpr == trueExpr &&
+      o.falseExpr == falseExpr;
 
-  int get hashCode => _JenkinsSmiHash.hash3(condition.hashCode,
-      trueExpr.hashCode, falseExpr.hashCode);
+  int get hashCode => _JenkinsSmiHash.hash3(
+      condition.hashCode, trueExpr.hashCode, falseExpr.hashCode);
 }
 
 class InExpression extends Expression implements HasIdentifier {
@@ -234,8 +238,8 @@ class InExpression extends Expression implements HasIdentifier {
 
   String toString() => '($left in $right)';
 
-  bool operator ==(o) => o is InExpression && o.left == left
-      && o.right == right;
+  bool operator ==(o) =>
+      o is InExpression && o.left == left && o.right == right;
 
   int get hashCode => _JenkinsSmiHash.hash2(left.hashCode, right.hashCode);
 }
@@ -254,8 +258,8 @@ class AsExpression extends Expression implements HasIdentifier {
 
   String toString() => '($left as $right)';
 
-  bool operator ==(o) => o is AsExpression && o.left == left
-      && o.right == right;
+  bool operator ==(o) =>
+      o is AsExpression && o.left == left && o.right == right;
 
   int get hashCode => _JenkinsSmiHash.hash2(left.hashCode, right.hashCode);
 }
@@ -271,9 +275,7 @@ class Index extends Expression {
   String toString() => '$receiver[$argument]';
 
   bool operator ==(o) =>
-      o is Index
-      && o.receiver == receiver
-      && o.argument == argument;
+      o is Index && o.receiver == receiver && o.argument == argument;
 
   int get hashCode =>
       _JenkinsSmiHash.hash2(receiver.hashCode, argument.hashCode);
@@ -290,12 +292,9 @@ class Getter extends Expression {
   String toString() => '$receiver.$name';
 
   bool operator ==(o) =>
-      o is Getter
-      && o.receiver == receiver
-      && o.name == name;
+      o is Getter && o.receiver == receiver && o.name == name;
 
   int get hashCode => _JenkinsSmiHash.hash2(receiver.hashCode, name.hashCode);
-
 }
 
 /**
@@ -318,13 +317,13 @@ class Invoke extends Expression {
   String toString() => '$receiver.$method($arguments)';
 
   bool operator ==(o) =>
-      o is Invoke
-      && o.receiver == receiver
-      && o.method == method
-      && _listEquals(o.arguments, arguments);
+      o is Invoke &&
+      o.receiver == receiver &&
+      o.method == method &&
+      _listEquals(o.arguments, arguments);
 
-  int get hashCode => _JenkinsSmiHash.hash3(receiver.hashCode, method.hashCode,
-      _hashList(arguments));
+  int get hashCode => _JenkinsSmiHash.hash3(
+      receiver.hashCode, method.hashCode, _hashList(arguments));
 }
 
 bool _listEquals(List a, List b) {
@@ -338,8 +337,7 @@ bool _listEquals(List a, List b) {
 }
 
 int _hashList(List l) {
-  var hash = l.fold(0,
-      (h, item) => _JenkinsSmiHash.combine(h, item.hashCode));
+  var hash = l.fold(0, (h, item) => _JenkinsSmiHash.combine(h, item.hashCode));
   return _JenkinsSmiHash.finish(hash);
 }
 
@@ -353,7 +351,7 @@ class _JenkinsSmiHash {
   }
 
   static int finish(int hash) {
-    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) <<  3));
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
     hash = hash ^ (hash >> 11);
     return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
   }

--- a/lib/filter.dart
+++ b/lib/filter.dart
@@ -7,7 +7,6 @@ library polymer_expressions.filter;
 typedef Object Filter(Object value);
 
 abstract class Transformer<T, V> {
-
   T forward(V v);
   V reverse(T t);
   Transformer<V, T> get inverse => new _InverseTransformer/*<V, T>*/(this);

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -9,8 +9,26 @@ export 'tokenizer.dart' show ParseException;
 import 'expression.dart';
 
 const _UNARY_OPERATORS = const <String>['+', '-', '!'];
-const _BINARY_OPERATORS = const <String>['+', '-', '*', '/', '%', '^', '==',
-    '!=', '>', '<', '>=', '<=', '||', '&&', '&', '===', '!==', '|'];
+const _BINARY_OPERATORS = const <String>[
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '^',
+  '==',
+  '!=',
+  '>',
+  '<',
+  '>=',
+  '<=',
+  '||',
+  '&&',
+  '&',
+  '===',
+  '!==',
+  '|'
+];
 
 Expression parse(String expr) => new Parser(expr).parse();
 
@@ -33,8 +51,8 @@ class Parser {
   }
 
   _advance([int kind, String value]) {
-    if ((kind != null && (_token == null || _token.kind != kind))
-        || (value != null && (_token == null || _token.value != value))) {
+    if ((kind != null && (_token == null || _token.kind != kind)) ||
+        (value != null && (_token == null || _token.value != value))) {
       throw new ParseException("Expected kind $kind ($value): $_token");
     }
     _iterator.moveNext();
@@ -75,8 +93,8 @@ class Parser {
         } else {
           break;
         }
-      } else if (_token.kind == OPERATOR_TOKEN
-          && _token.precedence >= precedence) {
+      } else if (_token.kind == OPERATOR_TOKEN &&
+          _token.precedence >= precedence) {
         left = _token.value == '?' ? _parseTernary(left) : _parseBinary(left);
       } else {
         break;
@@ -104,11 +122,11 @@ class Parser {
     }
     _advance();
     var right = _parseUnary();
-    while (_token != null
-        && (_token.kind == OPERATOR_TOKEN
-        || _token.kind == DOT_TOKEN
-        || _token.kind == GROUPER_TOKEN)
-        && _token.precedence > op.precedence) {
+    while (_token != null &&
+        (_token.kind == OPERATOR_TOKEN ||
+            _token.kind == DOT_TOKEN ||
+            _token.kind == GROUPER_TOKEN) &&
+        _token.precedence > op.precedence) {
       right = _parsePrecedence(right, _token.precedence);
     }
     return _astFactory.binary(left, op.value, right);
@@ -191,7 +209,7 @@ class Parser {
         break;
       }
       items.add(_parseExpression());
-    } while(_token != null && _token.value == ',');
+    } while (_token != null && _token.value == ',');
     _advance(GROUPER_TOKEN, ']');
     return new ListLiteral(items);
   }
@@ -204,7 +222,7 @@ class Parser {
         break;
       }
       entries.add(_parseMapLiteralEntry());
-    } while(_token != null && _token.value == ',');
+    } while (_token != null && _token.value == ',');
     _advance(GROUPER_TOKEN, '}');
     return new MapLiteral(entries);
   }
@@ -232,8 +250,7 @@ class Parser {
     _advance();
     var right = _parseExpression();
     if (right is! Identifier) {
-      throw new ParseException(
-          "'as' statements must end with an identifier");
+      throw new ParseException("'as' statements must end with an identifier");
     }
     return _astFactory.asExpr(left, right);
   }
@@ -279,7 +296,7 @@ class Parser {
         }
         var expr = _parseExpression();
         args.add(expr);
-      } while(_token != null && _token.value == ',');
+      } while (_token != null && _token.value == ',');
       _advance(GROUPER_TOKEN, ')');
       return args;
     }
@@ -320,5 +337,4 @@ class Parser {
     _advance();
     return value;
   }
-
 }

--- a/lib/polymer_expressions.dart
+++ b/lib/polymer_expressions.dart
@@ -38,19 +38,17 @@ import 'expression.dart';
 import 'parser.dart';
 import 'src/globals.dart';
 
-Object _classAttributeConverter(v) =>
-    (v is Map) ? v.keys.where((k) => v[k] == true).join(' ') :
-    (v is Iterable) ? v.join(' ') :
-    v;
+Object _classAttributeConverter(v) => (v is Map)
+    ? v.keys.where((k) => v[k] == true).join(' ')
+    : (v is Iterable) ? v.join(' ') : v;
 
-Object _styleAttributeConverter(v) =>
-    (v is Map) ? v.keys.map((k) => '$k: ${v[k]}').join(';') :
-    (v is Iterable) ? v.join(';') :
-    v;
+Object _styleAttributeConverter(v) => (v is Map)
+    ? v.keys.map((k) => '$k: ${v[k]}').join(';')
+    : (v is Iterable) ? v.join(';') : v;
 
 class PolymerExpressions extends BindingDelegate {
   /** The default [globals] to use for Polymer expressions. */
-  static const Map DEFAULT_GLOBALS = const { 'enumerate': enumerate };
+  static const Map DEFAULT_GLOBALS = const {'enumerate': enumerate};
 
   final ScopeFactory _scopeFactory;
   final Map<String, Object> globals;
@@ -65,11 +63,13 @@ class PolymerExpressions extends BindingDelegate {
    * variables used as [globals]. If no globals are supplied, a copy of the
    * [DEFAULT_GLOBALS] will be used.
    */
-  PolymerExpressions({Map<String, Object> globals,
+  PolymerExpressions(
+      {Map<String, Object> globals,
       ScopeFactory scopeFactory: const ScopeFactory()})
-      : globals = globals == null ?
-          new Map<String, Object>.from(DEFAULT_GLOBALS) : globals,
-          _scopeFactory = scopeFactory;
+      : globals = globals == null
+            ? new Map<String, Object>.from(DEFAULT_GLOBALS)
+            : globals,
+        _scopeFactory = scopeFactory;
 
   @override
   PrepareBindingFunction prepareBinding(String path, name, Node boundNode) {
@@ -259,13 +259,12 @@ class PolymerExpressions extends BindingDelegate {
   /// returns the value. Otherwise, when [oneTime] is false, it returns a
   /// [Bindable] that besides evaluating the expression, it will also react to
   /// observable changes from the model and update the value accordingly.
-  static getBinding(Expression expr, model, {Map<String, Object> globals,
-      oneTime: false}) {
+  static getBinding(Expression expr, model,
+      {Map<String, Object> globals, oneTime: false}) {
     if (globals == null) globals = new Map.from(DEFAULT_GLOBALS);
-    var scope = model is Scope ? model
-        : new Scope(model: model, variables: globals);
-    return oneTime ? _Binding._oneTime(expr, scope)
-        : new _Binding(expr, scope);
+    var scope =
+        model is Scope ? model : new Scope(model: model, variables: globals);
+    return oneTime ? _Binding._oneTime(expr, scope) : new _Binding(expr, scope);
   }
 }
 
@@ -288,8 +287,8 @@ class _Binding extends Bindable {
       var value = eval(expr, scope);
       return (converter == null) ? value : converter(value);
     } catch (e, s) {
-      new Completer().completeError(
-          "Error evaluating expression '$expr': $e", s);
+      new Completer()
+          .completeError("Error evaluating expression '$expr': $e", s);
     }
     return null;
   }
@@ -319,8 +318,8 @@ class _Binding extends Bindable {
     try {
       assign(_expr, v, _scope, checkAssignability: false);
     } catch (e, s) {
-      new Completer().completeError(
-          "Error evaluating expression '$_expr': $e", s);
+      new Completer()
+          .completeError("Error evaluating expression '$_expr': $e", s);
     }
   }
 
@@ -329,10 +328,11 @@ class _Binding extends Bindable {
 
     _callback = callback;
     _observer = observe(_expr, _scope);
-    _sub = _observer.onUpdate.listen(_convertAndCheck)..onError((e, s) {
-      new Completer().completeError(
-          "Error evaluating expression '$_observer': $e", s);
-    });
+    _sub = _observer.onUpdate.listen(_convertAndCheck)
+      ..onError((e, s) {
+        new Completer()
+            .completeError("Error evaluating expression '$_observer': $e", s);
+      });
 
     _check(skipChanges: true);
     return _value;
@@ -343,8 +343,8 @@ class _Binding extends Bindable {
       update(_observer, _scope, skipChanges: skipChanges);
       return _convertAndCheck(_observer.currentValue, skipChanges: skipChanges);
     } catch (e, s) {
-      new Completer().completeError(
-          "Error evaluating expression '$_observer': $e", s);
+      new Completer()
+          .completeError("Error evaluating expression '$_observer': $e", s);
       return false;
     }
   }
@@ -359,7 +359,6 @@ class _Binding extends Bindable {
     new Closer().visit(_observer);
     _observer = null;
   }
-
 
   // TODO(jmesserly): the following code is copy+pasted from path_observer.dart
   // What seems to be going on is: polymer_expressions.dart has its own _Binding

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -20,11 +20,12 @@ import 'package:observe/observe.dart' show reflectable;
 Iterable<IndexedValue> enumerate(Iterable iterable) =>
     new EnumerateIterable(iterable);
 
-@reflectable class IndexedValue<V> {
+@reflectable
+class IndexedValue<V> {
   final int index;
   final V value;
 
-  operator==(o) => o is IndexedValue && o.index == index && o.value == value;
+  operator ==(o) => o is IndexedValue && o.index == index && o.value == value;
   int get hashCode => value.hashCode;
   String toString() => '($index, $value)';
 

--- a/lib/tokenizer.dart
+++ b/lib/tokenizer.dart
@@ -50,30 +50,48 @@ const int _BAR = 124;
 const int _CLOSE_CURLY_BRACKET = 125;
 const int _NBSP = 160;
 
-const _OPERATORS = const [_PLUS, _MINUS, _STAR, _SLASH, _BANG, _AMPERSAND,
-                          _PERCENT, _LT, _EQ, _GT, _QUESTION, _CARET, _BAR];
+const _OPERATORS = const [
+  _PLUS,
+  _MINUS,
+  _STAR,
+  _SLASH,
+  _BANG,
+  _AMPERSAND,
+  _PERCENT,
+  _LT,
+  _EQ,
+  _GT,
+  _QUESTION,
+  _CARET,
+  _BAR
+];
 
-const _GROUPERS = const [_OPEN_PAREN, _CLOSE_PAREN,
-                         _OPEN_SQUARE_BRACKET, _CLOSE_SQUARE_BRACKET,
-                         _OPEN_CURLY_BRACKET, _CLOSE_CURLY_BRACKET];
+const _GROUPERS = const [
+  _OPEN_PAREN,
+  _CLOSE_PAREN,
+  _OPEN_SQUARE_BRACKET,
+  _CLOSE_SQUARE_BRACKET,
+  _OPEN_CURLY_BRACKET,
+  _CLOSE_CURLY_BRACKET
+];
 
 const _TWO_CHAR_OPS = const ['==', '!=', '<=', '>=', '||', '&&'];
 
 const KEYWORDS = const ['as', 'in', 'this'];
 
 const _PRECEDENCE = const {
-  '!':  0,
-  ':':  0,
-  ',':  0,
-  ')':  0,
-  ']':  0,
-  '}':  0, // ?
-  '?':  1,
+  '!': 0,
+  ':': 0,
+  ',': 0,
+  ')': 0,
+  ']': 0,
+  '}': 0, // ?
+  '?': 1,
   '||': 2,
   '&&': 3,
-  '|':  4,
-  '^':  5,
-  '&':  6,
+  '|': 4,
+  '^': 5,
+  '&': 6,
 
   // equality
   '!=': 7,
@@ -83,23 +101,23 @@ const _PRECEDENCE = const {
 
   // relational
   '>=': 8,
-  '>':  8,
+  '>': 8,
   '<=': 8,
-  '<':  8,
+  '<': 8,
 
   // additive
-  '+':  9,
-  '-':  9,
+  '+': 9,
+  '-': 9,
 
   // multiplicative
-  '%':  10,
-  '/':  10,
-  '*':  10,
+  '%': 10,
+  '/': 10,
+  '*': 10,
 
   // postfix
-  '(':  11,
-  '[':  11,
-  '.':  11,
+  '(': 11,
+  '[': 11,
+  '.': 11,
   '{': 11, //not sure this is correct
 };
 
@@ -118,12 +136,20 @@ const int KEYWORD_TOKEN = 10;
 
 bool isWhitespace(int next) => next == _SPACE || next == _TAB || next == _NBSP;
 
-bool isIdentifierOrKeywordStart(int next) => (_a <= next && next <= _z) ||
-    (_A <= next && next <= _Z) || next == _US || next == _$ || next > 127;
+bool isIdentifierOrKeywordStart(int next) =>
+    (_a <= next && next <= _z) ||
+    (_A <= next && next <= _Z) ||
+    next == _US ||
+    next == _$ ||
+    next > 127;
 
-bool isIdentifier(int next) => (_a <= next && next <= _z) ||
-    (_A <= next && next <= _Z) || (_0 <= next && next <= _9) ||
-    next == _US || next == _$ || next > 127;
+bool isIdentifier(int next) =>
+    (_a <= next && next <= _z) ||
+    (_A <= next && next <= _Z) ||
+    (_0 <= next && next <= _9) ||
+    next == _US ||
+    next == _$ ||
+    next > 127;
 
 bool isQuote(int next) => next == _DQ || next == _SQ;
 
@@ -135,12 +161,18 @@ bool isGrouper(int next) => _GROUPERS.contains(next);
 
 int escape(int c) {
   switch (c) {
-    case _f: return _FF;
-    case _n: return _LF;
-    case _r: return _CR;
-    case _t: return _TAB;
-    case _v: return _VTAB;
-    default: return c;
+    case _f:
+      return _FF;
+    case _n:
+      return _LF;
+    case _r:
+      return _CR;
+    case _t:
+      return _TAB;
+    case _v:
+      return _VTAB;
+    default:
+      return c;
   }
 }
 
@@ -169,7 +201,7 @@ class Tokenizer {
 
   List<Token> tokenize() {
     _advance();
-    while(_next != null) {
+    while (_next != null) {
       if (isWhitespace(_next)) {
         _advance();
       } else if (isQuote(_next)) {

--- a/test/eval_test.dart
+++ b/test/eval_test.dart
@@ -171,19 +171,12 @@ main() {
     });
 
     test('should call a filter', () {
-      var topLevel = {
-        'a': 'foo',
-        'uppercase': (s) => s.toUpperCase(),
-      };
+      var topLevel = {'a': 'foo', 'uppercase': (s) => s.toUpperCase(),};
       expectEval('a | uppercase', 'FOO', null, topLevel);
     });
 
     test('should call a transformer', () {
-      var topLevel = {
-        'a': '42',
-        'parseInt': parseInt,
-        'add': add,
-      };
+      var topLevel = {'a': '42', 'parseInt': parseInt, 'add': add,};
       expectEval('a | parseInt()', 42, null, topLevel);
       expectEval('a | parseInt(8)', 34, null, topLevel);
       expectEval('a | parseInt() | add(10)', 52, null, topLevel);
@@ -230,11 +223,9 @@ main() {
     test('should not evaluate "in" expressions', () {
       expect(() => eval(parse('item in items'), null), throws);
     });
-
   });
 
   group('assign', () {
-
     test('should assign a single identifier', () {
       var foo = new Foo(name: 'a');
       assign(parse('name'), 'b', new Scope(model: foo));
@@ -265,11 +256,7 @@ main() {
 
     test('should assign through transformers', () {
       var foo = new Foo(name: '42', age: 32);
-      var globals = {
-        'a': '42',
-        'parseInt': parseInt,
-        'add': add,
-      };
+      var globals = {'a': '42', 'parseInt': parseInt, 'add': add,};
       var scope = new Scope(model: foo, variables: globals);
       assign(parse('age | add(7)'), 29, scope);
       expect(foo.age, 22);
@@ -292,21 +279,19 @@ main() {
           throwsA(new isInstanceOf<EvalException>()));
     });
 
-    test('should not throw on assignments to non-assignable expressions if '
+    test(
+        'should not throw on assignments to non-assignable expressions if '
         'checkAssignability is false', () {
       var foo = new Foo(name: 'a');
       var scope = new Scope(model: foo);
       expect(
-          assign(parse('name + 1'), 1, scope, checkAssignability: false),
-          null);
-      expect(
-          assign(parse('toString()'), 1, scope, checkAssignability: false),
+          assign(parse('name + 1'), 1, scope, checkAssignability: false), null);
+      expect(assign(parse('toString()'), 1, scope, checkAssignability: false),
           null);
       expect(
           assign(parse('name | filter'), 1, scope, checkAssignability: false),
           null);
     });
-
   });
 
   group('scope', () {
@@ -334,48 +319,33 @@ main() {
       expect(parent['a'], 'A');
       expect(child['b'], 'B');
     });
-
   });
 
   group('observe', () {
     test('should observe an identifier', () {
       var foo = new Foo(name: 'foo');
-      return expectObserve('name',
-          model: foo,
-          beforeMatcher: 'foo',
+      return expectObserve('name', model: foo, beforeMatcher: 'foo',
           mutate: () {
-            foo.name = 'fooz';
-          },
-          afterMatcher: 'fooz'
-      );
+        foo.name = 'fooz';
+      }, afterMatcher: 'fooz');
     });
 
     test('should observe an invocation', () {
       var foo = new Foo(name: 'foo');
       return expectObserve('foo.name',
-          variables: {'foo': foo},
-          beforeMatcher: 'foo',
-          mutate: () {
-            foo.name = 'fooz';
-          },
-          afterMatcher: 'fooz'
-      );
+          variables: {'foo': foo}, beforeMatcher: 'foo', mutate: () {
+        foo.name = 'fooz';
+      }, afterMatcher: 'fooz');
     });
 
     test('should observe map access', () {
       var foo = toObservable({'one': 'one', 'two': 'two'});
       return expectObserve('foo["one"]',
-          variables: {'foo': foo},
-          beforeMatcher: 'one',
-          mutate: () {
-            foo['one'] = '1';
-          },
-          afterMatcher: '1'
-      );
+          variables: {'foo': foo}, beforeMatcher: 'one', mutate: () {
+        foo['one'] = '1';
+      }, afterMatcher: '1');
     });
-
   });
-
 }
 
 @reflectable
@@ -436,13 +406,12 @@ expectEval(String s, dynamic matcher, [Object model, Map vars = const {}]) {
   expect(observer.currentValue, matcher, reason: s);
 }
 
-expectObserve(String s, {
-    Object model,
+expectObserve(String s,
+    {Object model,
     Map variables: const {},
     dynamic beforeMatcher,
     mutate(),
     dynamic afterMatcher}) {
-
   var scope = new Scope(model: model, variables: variables);
   var observer = observe(new Parser(s).parse(), scope);
   update(observer, scope);
@@ -455,13 +424,19 @@ expectObserve(String s, {
   });
   mutate();
   // fail if we don't receive an update by the next event loop
-  return Future.wait([future, new Future(() {
-    expect(passed, true, reason: "Didn't receive a change notification on $s");
-  })]);
+  return Future.wait([
+    future,
+    new Future(() {
+      expect(passed, true,
+          reason: "Didn't receive a change notification on $s");
+    })
+  ]);
 }
 
 // Regression test from https://code.google.com/p/dart/issues/detail?id=13459
 class WordElement extends Observable {
-  @observable List chars1 = 'abcdefg'.split('');
-  @reflectable List filteredList(List original) => [original[0], original[1]];
+  @observable
+  List chars1 = 'abcdefg'.split('');
+  @reflectable
+  List filteredList(List original) => [original[0], original[1]];
 }

--- a/test/globals_test.dart
+++ b/test/globals_test.dart
@@ -40,9 +40,8 @@ main() {
 
     test('should enumerate item and index', () {
       templateBind(testDiv.query('template'))
-          ..bindingDelegate = new PolymerExpressions()
-          ..model = toObservable(
-              ['hello', 'from', 'polymer', 'expressions']);
+        ..bindingDelegate = new PolymerExpressions()
+        ..model = toObservable(['hello', 'from', 'polymer', 'expressions']);
 
       return new Future(() {
         expect(testDiv.queryAll('div').map((n) => n.text), [
@@ -56,11 +55,11 @@ main() {
 
     test('should update after changes', () {
       var model = toObservable(
-              ['hello', 'from', 'polymer', 'expressions', 'a', 'b', 'c']);
+          ['hello', 'from', 'polymer', 'expressions', 'a', 'b', 'c']);
 
       templateBind(testDiv.query('template'))
-          ..bindingDelegate = new PolymerExpressions()
-          ..model = model;
+        ..bindingDelegate = new PolymerExpressions()
+        ..model = model;
 
       return new Future(() {
         expect(testDiv.queryAll('div').map((n) => n.text), [

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -15,9 +15,7 @@ final Matcher throwsParseException =
     throwsA(new isInstanceOf<ParseException>('ParseException'));
 
 main() {
-
   group('parser', () {
-
     test('should parse an empty expression', () {
       expectParse('', empty());
     });
@@ -56,8 +54,26 @@ main() {
     });
 
     test('should parse binary operators', () {
-      var operators = ['+', '-', '*', '/', '%', '^', '==', '!=', '>', '<',
-          '>=', '<=', '||', '&&', '&', '===', '!==', '|'];
+      var operators = [
+        '+',
+        '-',
+        '*',
+        '/',
+        '%',
+        '^',
+        '==',
+        '!=',
+        '>',
+        '<',
+        '>=',
+        '<=',
+        '||',
+        '&&',
+        '&',
+        '===',
+        '!==',
+        '|'
+      ];
       for (var op in operators) {
         expectParse('a $op b', binary(ident('a'), op, ident('b')));
         expectParse('1 $op 2', binary(literal(1), op, literal(2)));
@@ -99,21 +115,21 @@ main() {
     });
 
     test('should parse a function call as a subexpression', () {
-      expectParse('a() + 1',
-          binary(
-              invoke(ident('a'), null, []),
-              '+',
-              literal(1)));
+      expectParse(
+          'a() + 1', binary(invoke(ident('a'), null, []), '+', literal(1)));
     });
 
     test('should parse multiple function arguments', () {
-      expectParse('a(b, c)',
-          invoke(ident('a'), null, [ident('b'), ident('c')]));
+      expectParse(
+          'a(b, c)', invoke(ident('a'), null, [ident('b'), ident('c')]));
     });
 
     test('should parse nested function calls', () {
-      expectParse('a(b(c))', invoke(ident('a'), null, [
-          invoke(ident('b'), null, [ident('c')])]));
+      expectParse(
+          'a(b(c))',
+          invoke(ident('a'), null, [
+            invoke(ident('b'), null, [ident('c')])
+          ]));
     });
 
     test('should parse an empty method call', () {
@@ -125,8 +141,8 @@ main() {
     });
 
     test('should parse a method call with multiple arguments', () {
-      expectParse('a.b(c, d)',
-          invoke(ident('a'), 'b', [ident('c'), ident('d')]));
+      expectParse(
+          'a.b(c, d)', invoke(ident('a'), 'b', [ident('c'), ident('d')]));
     });
 
     test('should parse chained method calls', () {
@@ -139,9 +155,10 @@ main() {
 
     test('should parse parenthesized expression', () {
       expectParse('(a)', paren(ident('a')));
-      expectParse('(( 3 * ((1 + 2)) ))', paren(paren(
-          binary(literal(3), '*', paren(paren(
-              binary(literal(1), '+', literal(2))))))));
+      expectParse(
+          '(( 3 * ((1 + 2)) ))',
+          paren(paren(binary(literal(3), '*',
+              paren(paren(binary(literal(1), '+', literal(2))))))));
     });
 
     test('should parse an index operator', () {
@@ -154,45 +171,52 @@ main() {
     });
 
     test('should parse multiple index operators', () {
-      expectParse('a[b] + c[d]', binary(
-          index(ident('a'), ident('b')),
-          '+',
-          index(ident('c'), ident('d'))));
+      expectParse(
+          'a[b] + c[d]',
+          binary(index(ident('a'), ident('b')), '+',
+              index(ident('c'), ident('d'))));
     });
 
     test('should parse ternary operators', () {
       expectParse('a ? b : c', ternary(ident('a'), ident('b'), ident('c')));
-      expectParse('a.a ? b.a : c.a', ternary(getter(ident('a'), 'a'),
-          getter(ident('b'), 'a'), getter(ident('c'), 'a')));
+      expectParse(
+          'a.a ? b.a : c.a',
+          ternary(getter(ident('a'), 'a'), getter(ident('b'), 'a'),
+              getter(ident('c'), 'a')));
       expect(() => parse('a + 1 ? b + 1 :: c.d + 3'), throwsParseException);
     });
 
     test('ternary operators have lowest associativity', () {
-      expectParse('a == b ? c + d : e - f', ternary(
-            binary(ident('a'), '==', ident('b')),
-            binary(ident('c'), '+', ident('d')),
-            binary(ident('e'), '-', ident('f'))));
+      expectParse(
+          'a == b ? c + d : e - f',
+          ternary(
+              binary(ident('a'), '==', ident('b')),
+              binary(ident('c'), '+', ident('d')),
+              binary(ident('e'), '-', ident('f'))));
 
-      expectParse('a.x == b.y ? c + d : e - f', ternary(
-            binary(getter(ident('a'), 'x'), '==', getter(ident('b'), 'y')),
-            binary(ident('c'), '+', ident('d')),
-            binary(ident('e'), '-', ident('f'))));
+      expectParse(
+          'a.x == b.y ? c + d : e - f',
+          ternary(
+              binary(getter(ident('a'), 'x'), '==', getter(ident('b'), 'y')),
+              binary(ident('c'), '+', ident('d')),
+              binary(ident('e'), '-', ident('f'))));
 
-      expectParse('a.x == b.y ? c + d : e - f', ternary(
-            binary(getter(ident('a'), 'x'), '==', getter(ident('b'), 'y')),
-            binary(ident('c'), '+', ident('d')),
-            binary(ident('e'), '-', ident('f'))));
+      expectParse(
+          'a.x == b.y ? c + d : e - f',
+          ternary(
+              binary(getter(ident('a'), 'x'), '==', getter(ident('b'), 'y')),
+              binary(ident('c'), '+', ident('d')),
+              binary(ident('e'), '-', ident('f'))));
     });
 
     test('should parse a filter chain', () {
-      expectParse('a | b | c', binary(binary(ident('a'), '|', ident('b')),
-          '|', ident('c')));
+      expectParse('a | b | c',
+          binary(binary(ident('a'), '|', ident('b')), '|', ident('c')));
     });
 
     test('should parse "in" expression', () {
       expectParse('a in b', inExpr(ident('a'), ident('b')));
-      expectParse('a in b.c',
-          inExpr(ident('a'), getter(ident('b'), 'c')));
+      expectParse('a in b.c', inExpr(ident('a'), getter(ident('b'), 'c')));
       expectParse('a in b + c',
           inExpr(ident('a'), binary(ident('b'), '+', ident('c'))));
     });
@@ -212,33 +236,42 @@ main() {
     });
 
     test('should parse map literals', () {
-      expectParse("{'a': 1}",
-          mapLiteral([mapLiteralEntry(literal('a'), literal(1))]));
-      expectParse("{'a': 1, 'b': 2 + 3}",
+      expectParse(
+          "{'a': 1}", mapLiteral([mapLiteralEntry(literal('a'), literal(1))]));
+      expectParse(
+          "{'a': 1, 'b': 2 + 3}",
           mapLiteral([
-              mapLiteralEntry(literal('a'), literal(1)),
-              mapLiteralEntry(literal('b'),
-                  binary(literal(2), '+', literal(3)))]));
-      expectParse("{'a': foo()}",
-          mapLiteral([mapLiteralEntry(
-              literal('a'), invoke(ident('foo'), null, []))]));
-      expectParse("{'a': foo('a')}",
-          mapLiteral([mapLiteralEntry(
-              literal('a'), invoke(ident('foo'), null, [literal('a')]))]));
+            mapLiteralEntry(literal('a'), literal(1)),
+            mapLiteralEntry(literal('b'), binary(literal(2), '+', literal(3)))
+          ]));
+      expectParse(
+          "{'a': foo()}",
+          mapLiteral(
+              [mapLiteralEntry(literal('a'), invoke(ident('foo'), null, []))]));
+      expectParse(
+          "{'a': foo('a')}",
+          mapLiteral([
+            mapLiteralEntry(
+                literal('a'), invoke(ident('foo'), null, [literal('a')]))
+          ]));
     });
 
     test('should parse map literals with method calls', () {
-      expectParse("{'a': 1}.length",
+      expectParse(
+          "{'a': 1}.length",
           getter(mapLiteral([mapLiteralEntry(literal('a'), literal(1))]),
               'length'));
     });
 
     test('should parse list literals', () {
-      expectParse('[1, "a", b]',
-          listLiteral([literal(1), literal('a'), ident('b')]));
-      expectParse('[[1, 2], [3, 4]]',
-          listLiteral([listLiteral([literal(1), literal(2)]),
-                       listLiteral([literal(3), literal(4)])]));
+      expectParse(
+          '[1, "a", b]', listLiteral([literal(1), literal('a'), ident('b')]));
+      expectParse(
+          '[[1, 2], [3, 4]]',
+          listLiteral([
+            listLiteral([literal(1), literal(2)]),
+            listLiteral([literal(3), literal(4)])
+          ]));
     });
   });
 }

--- a/test/syntax_test.dart
+++ b/test/syntax_test.dart
@@ -48,15 +48,15 @@ main() {
     });
 
     Future<Element> setUpTest(String html, {model, Map globals}) {
-      var tag = new Element.html(html,
-          treeSanitizer: new NullNodeTreeSanitizer());
+      var tag =
+          new Element.html(html, treeSanitizer: new NullNodeTreeSanitizer());
 
       // make sure templates behave in the polyfill
       TemplateBindExtension.bootstrap(tag);
 
       templateBind(tag)
-        ..bindingDelegate = new PolymerExpressions(globals: globals,
-            scopeFactory: testScopeFactory)
+        ..bindingDelegate = new PolymerExpressions(
+            globals: globals, scopeFactory: testScopeFactory)
         ..model = model;
       testDiv.children.clear();
       testDiv.append(tag);
@@ -75,34 +75,37 @@ main() {
       // We could try to optimize the outer scope away in cases where the
       // expression is empty, but there are a lot of special cases in the
       // syntax code already.
-      test('should create one scope for a single binding', () =>
-        setUpTest('''
+      test(
+          'should create one scope for a single binding',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ data }}</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, 'a');
-          expect(testScopeFactory.scopeCount, 1);
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, 'a');
+                expect(testScopeFactory.scopeCount, 1);
+              }));
 
-      test('should only create a single scope for two bindings', () =>
-        setUpTest('''
+      test(
+          'should only create a single scope for two bindings',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ data }}</div>
               <div>{{ data }}</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 3);
-          expect(testDiv.children[1].text, 'a');
-          expect(testDiv.children[2].text, 'a');
-          expect(testScopeFactory.scopeCount, 1);
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 3);
+                expect(testDiv.children[1].text, 'a');
+                expect(testDiv.children[2].text, 'a');
+                expect(testScopeFactory.scopeCount, 1);
+              }));
 
       test('should create a new scope for a bind/as binding', () {
-        return setUpTest('''
+        return setUpTest(
+            '''
             <template id="test" bind>
               <div>{{ data }}</div>
               <template bind="{{ data as a }}" id="inner">
@@ -110,8 +113,7 @@ main() {
                 <div>{{ data }}</div>
               </template>
             </template>''',
-            model: new Model('foo'))
-        .then((_) {
+            model: new Model('foo')).then((_) {
           expect(testDiv.children.length, 5);
           expect(testDiv.children[1].text, 'foo');
           expect(testDiv.children[3].text, 'foo');
@@ -121,7 +123,8 @@ main() {
       });
 
       test('should create scopes for a repeat/in binding', () {
-        return setUpTest('''
+        return setUpTest(
+            '''
             <template id="test" bind>
               <div>{{ data }}</div>
               <template repeat="{{ i in items }}" id="inner">
@@ -129,8 +132,10 @@ main() {
                 <div>{{ data }}</div>
               </template>
             </template>''',
-            model: new Model('foo'), globals: {'items': ['a', 'b', 'c']})
-        .then((_) {
+            model: new Model('foo'),
+            globals: {
+              'items': ['a', 'b', 'c']
+            }).then((_) {
           expect(testDiv.children.length, 9);
           expect(testDiv.children[1].text, 'foo');
           expect(testDiv.children[3].text, 'a');
@@ -143,97 +148,101 @@ main() {
           expect(testScopeFactory.scopeCount, 4);
         });
       });
-
-
     });
 
     group('with template bind', () {
-
-      test('should show a simple binding on the model', () =>
-        setUpTest('''
+      test(
+          'should show a simple binding on the model',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ data }}</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, 'a');
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, 'a');
+              }));
 
-      test('should handle an empty binding on the model', () =>
-        setUpTest('''
+      test(
+          'should handle an empty binding on the model',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ }}</div>
             </template>''',
-            model: 'a')
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, 'a');
-        }));
+                  model: 'a').then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, 'a');
+              }));
 
-      test('should show a simple binding to a global', () =>
-        setUpTest('''
+      test(
+          'should show a simple binding to a global',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ a }}</div>
             </template>''',
-            globals: {'a': '123'})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, '123');
-        }));
+                  globals: {'a': '123'}).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, '123');
+              }));
 
-      test('should show an expression binding', () =>
-        setUpTest('''
+      test(
+          'should show an expression binding',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ data + 'b' }}</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, 'ab');
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, 'ab');
+              }));
 
-      test('should handle an expression in the bind attribute', () =>
-        setUpTest('''
+      test(
+          'should handle an expression in the bind attribute',
+          () => setUpTest(
+                  '''
             <template id="test" bind="{{ data }}">
               <div>{{ this }}</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].text, 'a');
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].text, 'a');
+              }));
 
-      test('should handle a nested template with an expression in the bind '
-          'attribute', () =>
-        setUpTest('''
+      test(
+          'should handle a nested template with an expression in the bind '
+          'attribute',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <template id="inner" bind="{{ data }}">
                 <div>{{ this }}</div>
               </template>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 3);
-          expect(testDiv.children[2].text, 'a');
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 3);
+                expect(testDiv.children[2].text, 'a');
+              }));
 
-
-      test('should handle an "as" expression in the bind attribute', () =>
-        setUpTest('''
+      test(
+          'should handle an "as" expression in the bind attribute',
+          () => setUpTest(
+                  '''
             <template id="test" bind="{{ data as a }}">
               <div>{{ data }}b</div>
               <div>{{ a }}c</div>
             </template>''',
-            model: new Model('a'))
-        .then((_) {
-          expect(testDiv.children.length, 3);
-          expect(testDiv.children[1].text, 'ab');
-          expect(testDiv.children[2].text, 'ac');
-        }));
+                  model: new Model('a')).then((_) {
+                expect(testDiv.children.length, 3);
+                expect(testDiv.children[1].text, 'ab');
+                expect(testDiv.children[2].text, 'ac');
+              }));
 
       // passes safari
-      test('should not resolve names in the outer template from within a nested'
+      test(
+          'should not resolve names in the outer template from within a nested'
           ' template with a bind binding', () {
         var completer = new Completer();
         var bindingErrorHappened = false;
@@ -244,7 +253,8 @@ main() {
           }
         }
         runZoned(() {
-          setUpTest('''
+          setUpTest(
+              '''
               <template id="test" bind>
                 <div>{{ data }}</div>
                 <div>{{ b }}</div>
@@ -254,8 +264,8 @@ main() {
                   <div>{{ this }}</div>
                 </template>
               </template>''',
-              model: new Model('foo'), globals: {'b': 'bbb'})
-          .then((_) {
+              model: new Model('foo'),
+              globals: {'b': 'bbb'}).then((_) {
             expect(testDiv.children[0].text, '');
             expect(testDiv.children[1].text, 'foo');
             expect(testDiv.children[2].text, 'bbb');
@@ -279,9 +289,11 @@ main() {
       });
 
       // passes safari
-      test('should shadow names in the outer template from within a nested '
-          'template', () =>
-          setUpTest('''
+      test(
+          'should shadow names in the outer template from within a nested '
+          'template',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ a }}</div>
               <div>{{ b }}</div>
@@ -290,22 +302,20 @@ main() {
                 <div>{{ b }}</div>
               </template>
             </template>''',
-            globals: {'a': 'aaa', 'b': 'bbb'})
-        .then((_) {
-          expect(testDiv.children[0].text, '');
-          expect(testDiv.children[1].text, 'aaa');
-          expect(testDiv.children[2].text, 'bbb');
-          expect(testDiv.children[3].tagName.toLowerCase(), 'template');
-          expect(testDiv.children[4].text, 'bbb');
-          expect(testDiv.children[5].text, 'bbb');
-        }));
-
+                  globals: {'a': 'aaa', 'b': 'bbb'}).then((_) {
+                expect(testDiv.children[0].text, '');
+                expect(testDiv.children[1].text, 'aaa');
+                expect(testDiv.children[2].text, 'bbb');
+                expect(testDiv.children[3].tagName.toLowerCase(), 'template');
+                expect(testDiv.children[4].text, 'bbb');
+                expect(testDiv.children[5].text, 'bbb');
+              }));
     });
 
     group('with template repeat', () {
-
       // passes safari
-      test('should not resolve names in the outer template from within a nested'
+      test(
+          'should not resolve names in the outer template from within a nested'
           ' template with a repeat binding', () {
         var completer = new Completer();
         var bindingErrorHappened = false;
@@ -316,16 +326,18 @@ main() {
           }
         }
         runZoned(() {
-          setUpTest('''
+          setUpTest(
+              '''
               <template id="test" bind>
                 <div>{{ data }}</div>
                 <template repeat="{{ items }}">
                   <div>{{ }}{{ data }}</div>
                 </template>
               </template>''',
-              globals: {'items': [1, 2, 3]},
-              model: new Model('a'))
-          .then((_) {
+              globals: {
+                'items': [1, 2, 3]
+              },
+              model: new Model('a')).then((_) {
             expect(testDiv.children[0].text, '');
             expect(testDiv.children[1].text, 'a');
             expect(testDiv.children[2].tagName.toLowerCase(), 'template');
@@ -343,39 +355,42 @@ main() {
         return completer.future;
       });
 
-      test('should handle repeat/in bindings', () =>
-        setUpTest('''
+      test(
+          'should handle repeat/in bindings',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ data }}</div>
               <template repeat="{{ item in items }}">
                 <div>{{ item }}{{ data }}</div>
               </template>
             </template>''',
-            globals: {'items': [1, 2, 3]},
-            model: new Model('a'))
-        .then((_) {
-          // expect 6 children: two templates, a div and three instances
-          expect(testDiv.children[0].text, '');
-          expect(testDiv.children[1].text, 'a');
-          expect(testDiv.children[2].tagName.toLowerCase(), 'template');
-          expect(testDiv.children[3].text, '1a');
-          expect(testDiv.children[4].text, '2a');
-          expect(testDiv.children[5].text, '3a');
+                  globals: {
+                    'items': [1, 2, 3]
+                  },
+                  model: new Model('a')).then((_) {
+                // expect 6 children: two templates, a div and three instances
+                expect(testDiv.children[0].text, '');
+                expect(testDiv.children[1].text, 'a');
+                expect(testDiv.children[2].tagName.toLowerCase(), 'template');
+                expect(testDiv.children[3].text, '1a');
+                expect(testDiv.children[4].text, '2a');
+                expect(testDiv.children[5].text, '3a');
 //          expect(testDiv.children.map((c) => c.text),
 //              ['', 'a', '', '1a', '2a', '3a']);
-        }));
+              }));
 
       test('should observe changes to lists in repeat bindings', () {
         var items = new ObservableList.from([1, 2, 3]);
-        return setUpTest('''
+        return setUpTest(
+            '''
             <template id="test" bind>
               <template repeat="{{ items }}">
                 <div>{{ }}</div>
               </template>
             </template>''',
             globals: {'items': items},
-            model: new Model('a'))
-        .then((_) {
+            model: new Model('a')).then((_) {
           expect(testDiv.children[0].text, '');
           expect(testDiv.children[1].tagName.toLowerCase(), 'template');
           expect(testDiv.children[2].text, '1');
@@ -399,15 +414,15 @@ main() {
 
       test('should observe changes to lists in repeat/in bindings', () {
         var items = new ObservableList.from([1, 2, 3]);
-        return setUpTest('''
+        return setUpTest(
+            '''
             <template id="test" bind>
               <template repeat="{{ item in items }}">
                 <div>{{ item }}</div>
               </template>
             </template>''',
             globals: {'items': items},
-            model: new Model('a'))
-        .then((_) {
+            model: new Model('a')).then((_) {
           expect(testDiv.children[0].text, '');
           expect(testDiv.children[1].tagName.toLowerCase(), 'template');
           expect(testDiv.children[2].text, '1');
@@ -431,54 +446,47 @@ main() {
     });
 
     group('with template if', () {
-
-      Future doTest(value, bool shouldRender) =>
-        setUpTest('''
+      Future doTest(value, bool shouldRender) => setUpTest(
+              '''
             <template id="test" bind>
               <div>{{ data }}</div>
               <template if="{{ show }}">
                 <div>{{ data }}</div>
               </template>
             </template>''',
-            globals: {'show': value},
-            model: new Model('a'))
-        .then((_) {
-          if (shouldRender) {
-            expect(testDiv.children.length, 4);
-            expect(testDiv.children[1].text, 'a');
-            expect(testDiv.children[3].text, 'a');
-          } else {
-            expect(testDiv.children.length, 3);
-            expect(testDiv.children[1].text, 'a');
-          }
-        });
+              globals: {'show': value},
+              model: new Model('a')).then((_) {
+            if (shouldRender) {
+              expect(testDiv.children.length, 4);
+              expect(testDiv.children[1].text, 'a');
+              expect(testDiv.children[3].text, 'a');
+            } else {
+              expect(testDiv.children.length, 3);
+              expect(testDiv.children[1].text, 'a');
+            }
+          });
 
-      test('should render for a true expression',
-          () => doTest(true, true));
+      test('should render for a true expression', () => doTest(true, true));
 
       test('should treat a non-null expression as truthy',
           () => doTest('a', true));
 
-      test('should treat an empty list as truthy',
-          () => doTest([], true));
+      test('should treat an empty list as truthy', () => doTest([], true));
 
-      test('should handle a false expression',
-          () => doTest(false, false));
+      test('should handle a false expression', () => doTest(false, false));
 
-      test('should treat null as falsey',
-          () => doTest(null, false));
+      test('should treat null as falsey', () => doTest(null, false));
     });
 
     group('error handling', () {
-
       test('should silently handle bad variable names', () {
         var completer = new Completer();
         runZoned(() {
           testDiv.nodes.add(new Element.html('''
               <template id="test" bind>{{ foo }}</template>'''));
           templateBind(query('#test'))
-              ..bindingDelegate = new PolymerExpressions()
-              ..model = [];
+            ..bindingDelegate = new PolymerExpressions()
+            ..model = [];
           return new Future(() {});
         }, onError: (e, s) {
           expect('$e', contains('foo'));
@@ -487,76 +495,88 @@ main() {
         return completer.future;
       });
 
-      test('should handle null collections in "in" expressions', () =>
-        setUpTest('''
+      test(
+          'should handle null collections in "in" expressions',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <template repeat="{{ item in items }}">
                 {{ item }}
               </template>
             </template>''',
-            globals: {'items': null})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[0].id, 'test');
-        }));
-
+                  globals: {'items': null}).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[0].id, 'test');
+              }));
     });
 
     group('special bindings', () {
-
-      test('should handle class attributes with lists', ()  =>
-        setUpTest('''
+      test(
+          'should handle class attributes with lists',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div class="{{ classes }}">
             </template>''',
-            globals: {'classes': ['a', 'b']})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].attributes['class'], 'a b');
-          expect(testDiv.children[1].classes, ['a', 'b']);
-        }));
+                  globals: {
+                    'classes': ['a', 'b']
+                  }).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].attributes['class'], 'a b');
+                expect(testDiv.children[1].classes, ['a', 'b']);
+              }));
 
-      test('should handle class attributes with maps', ()  =>
-        setUpTest('''
+      test(
+          'should handle class attributes with maps',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div class="{{ classes }}">
             </template>''',
-            globals: {'classes': {'a': true, 'b': false, 'c': true}})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].attributes['class'], 'a c');
-          expect(testDiv.children[1].classes, ['a', 'c']);
-        }));
+                  globals: {
+                    'classes': {'a': true, 'b': false, 'c': true}
+                  }).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].attributes['class'], 'a c');
+                expect(testDiv.children[1].classes, ['a', 'c']);
+              }));
 
-      test('should handle style attributes with lists', () =>
-        setUpTest('''
+      test(
+          'should handle style attributes with lists',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div style="{{ styles }}">
             </template>''',
-            globals: {'styles': ['display: none', 'color: black']})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].attributes['style'],
-              'display: none;color: black');
-        }));
+                  globals: {
+                    'styles': ['display: none', 'color: black']
+                  }).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].attributes['style'],
+                    'display: none;color: black');
+              }));
 
-      test('should handle style attributes with maps', ()  =>
-        setUpTest('''
+      test(
+          'should handle style attributes with maps',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div style="{{ styles }}">
             </template>''',
-            globals: {'styles': {'display': 'none', 'color': 'black'}})
-        .then((_) {
-          expect(testDiv.children.length, 2);
-          expect(testDiv.children[1].attributes['style'],
-              'display: none;color: black');
-        }));
+                  globals: {
+                    'styles': {'display': 'none', 'color': 'black'}
+                  }).then((_) {
+                expect(testDiv.children.length, 2);
+                expect(testDiv.children[1].attributes['style'],
+                    'display: none;color: black');
+              }));
     });
 
     group('regression tests', () {
-
-      test('should bind to literals', () =>
-        setUpTest('''
+      test(
+          'should bind to literals',
+          () => setUpTest(
+                  '''
             <template id="test" bind>
               <div>{{ 123 }}</div>
               <div>{{ 123.456 }}</div>
@@ -564,18 +584,15 @@ main() {
               <div>{{ true }}</div>
               <div>{{ null }}</div>
             </template>''',
-            globals: {'items': null})
-        .then((_) {
-          expect(testDiv.children.length, 6);
-          expect(testDiv.children[1].text, '123');
-          expect(testDiv.children[2].text, '123.456');
-          expect(testDiv.children[3].text, 'abc');
-          expect(testDiv.children[4].text, 'true');
-          expect(testDiv.children[5].text, '');
-        }));
-
-      });
-
+                  globals: {'items': null}).then((_) {
+                expect(testDiv.children.length, 6);
+                expect(testDiv.children[1].text, '123');
+                expect(testDiv.children[2].text, '123.456');
+                expect(testDiv.children[3].text, 'abc');
+                expect(testDiv.children[4].text, 'true');
+                expect(testDiv.children[5].text, '');
+              }));
+    });
   });
 }
 
@@ -604,7 +621,6 @@ class Model extends ChangeNotifier {
 }
 
 class NullNodeTreeSanitizer implements NodeTreeSanitizer {
-
   @override
   void sanitizeTree(Node node) {}
 }

--- a/test/tokenizer_test.dart
+++ b/test/tokenizer_test.dart
@@ -8,9 +8,7 @@ import 'package:polymer_expressions/tokenizer.dart';
 import 'package:unittest/unittest.dart';
 
 main() {
-
   group('tokenizer', () {
-
     test('should tokenize an empty expression', () {
       expectTokens('', []);
     });
@@ -33,52 +31,56 @@ main() {
 
     test('should tokenize a dot operator', () {
       expectTokens('a.b', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(DOT_TOKEN, '.'),
-          t(IDENTIFIER_TOKEN, 'b')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(DOT_TOKEN, '.'),
+        t(IDENTIFIER_TOKEN, 'b')
+      ]);
     });
 
     test('should tokenize a unary plus operator', () {
-      expectTokens('+a', [
-          t(OPERATOR_TOKEN, '+'),
-          t(IDENTIFIER_TOKEN, 'a')]);
+      expectTokens('+a', [t(OPERATOR_TOKEN, '+'), t(IDENTIFIER_TOKEN, 'a')]);
     });
 
     test('should tokenize a binary plus operator', () {
       expectTokens('a + b', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(OPERATOR_TOKEN, '+'),
-          t(IDENTIFIER_TOKEN, 'b')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(OPERATOR_TOKEN, '+'),
+        t(IDENTIFIER_TOKEN, 'b')
+      ]);
     });
 
     test('should tokenize a logical and operator', () {
       expectTokens('a && b', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(OPERATOR_TOKEN, '&&'),
-          t(IDENTIFIER_TOKEN, 'b')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(OPERATOR_TOKEN, '&&'),
+        t(IDENTIFIER_TOKEN, 'b')
+      ]);
     });
 
     test('should tokenize a ternary operator', () {
       expectTokens('a ? b : c', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(OPERATOR_TOKEN, '?'),
-          t(IDENTIFIER_TOKEN, 'b'),
-          t(COLON_TOKEN, ':'),
-          t(IDENTIFIER_TOKEN, 'c')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(OPERATOR_TOKEN, '?'),
+        t(IDENTIFIER_TOKEN, 'b'),
+        t(COLON_TOKEN, ':'),
+        t(IDENTIFIER_TOKEN, 'c')
+      ]);
     });
 
     test('should tokenize "in" expressions', () {
       expectTokens('item in items', [
-          t(IDENTIFIER_TOKEN, 'item'),
-          t(KEYWORD_TOKEN, 'in'),
-          t(IDENTIFIER_TOKEN, 'items')]);
+        t(IDENTIFIER_TOKEN, 'item'),
+        t(KEYWORD_TOKEN, 'in'),
+        t(IDENTIFIER_TOKEN, 'items')
+      ]);
     });
 
     test('should takenize an "as" expression', () {
       expectTokens('a as b', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(KEYWORD_TOKEN, 'as'),
-          t(IDENTIFIER_TOKEN, 'b')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(KEYWORD_TOKEN, 'as'),
+        t(IDENTIFIER_TOKEN, 'b')
+      ]);
     });
 
     test('should tokenize keywords', () {
@@ -89,43 +91,47 @@ main() {
 
     test('should tokenize groups', () {
       expectTokens('a(b)[]{}', [
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(GROUPER_TOKEN, '('),
-          t(IDENTIFIER_TOKEN, 'b'),
-          t(GROUPER_TOKEN, ')'),
-          t(GROUPER_TOKEN, '['),
-          t(GROUPER_TOKEN, ']'),
-          t(GROUPER_TOKEN, '{'),
-          t(GROUPER_TOKEN, '}')]);
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(GROUPER_TOKEN, '('),
+        t(IDENTIFIER_TOKEN, 'b'),
+        t(GROUPER_TOKEN, ')'),
+        t(GROUPER_TOKEN, '['),
+        t(GROUPER_TOKEN, ']'),
+        t(GROUPER_TOKEN, '{'),
+        t(GROUPER_TOKEN, '}')
+      ]);
     });
 
     test('should tokenize argument lists', () {
       expectTokens('(a, b)', [
-          t(GROUPER_TOKEN, '('),
-          t(IDENTIFIER_TOKEN, 'a'),
-          t(COMMA_TOKEN, ','),
-          t(IDENTIFIER_TOKEN, 'b'),
-          t(GROUPER_TOKEN, ')')]);
+        t(GROUPER_TOKEN, '('),
+        t(IDENTIFIER_TOKEN, 'a'),
+        t(COMMA_TOKEN, ','),
+        t(IDENTIFIER_TOKEN, 'b'),
+        t(GROUPER_TOKEN, ')')
+      ]);
     });
 
     test('should tokenize maps', () {
       expectTokens("{'a': b}", [
-          t(GROUPER_TOKEN, '{'),
-          t(STRING_TOKEN, 'a'),
-          t(COLON_TOKEN, ':'),
-          t(IDENTIFIER_TOKEN, 'b'),
-          t(GROUPER_TOKEN, '}')]);
+        t(GROUPER_TOKEN, '{'),
+        t(STRING_TOKEN, 'a'),
+        t(COLON_TOKEN, ':'),
+        t(IDENTIFIER_TOKEN, 'b'),
+        t(GROUPER_TOKEN, '}')
+      ]);
     });
 
     test('should tokenize lists', () {
       expectTokens("[1, 'a', b]", [
-          t(GROUPER_TOKEN, '['),
-          t(INTEGER_TOKEN, '1'),
-          t(COMMA_TOKEN, ','),
-          t(STRING_TOKEN, 'a'),
-          t(COMMA_TOKEN, ','),
-          t(IDENTIFIER_TOKEN, 'b'),
-          t(GROUPER_TOKEN, ']')]);
+        t(GROUPER_TOKEN, '['),
+        t(INTEGER_TOKEN, '1'),
+        t(COMMA_TOKEN, ','),
+        t(STRING_TOKEN, 'a'),
+        t(COMMA_TOKEN, ','),
+        t(IDENTIFIER_TOKEN, 'b'),
+        t(GROUPER_TOKEN, ']')
+      ]);
     });
 
     test('should tokenize integers', () {
@@ -144,7 +150,6 @@ main() {
       expectTokens('true', [t(IDENTIFIER_TOKEN, 'true')]);
       expectTokens('false', [t(IDENTIFIER_TOKEN, 'false')]);
     });
-
   });
 }
 
@@ -181,11 +186,7 @@ class MatcherList extends Matcher {
     for (int i = 0; i < o.length; i++) {
       var state = new Map();
       if (!matchers[i].matches(o[i], state)) {
-        matchState.addAll({
-          'index': i,
-          'value': o[i],
-          'state': state,
-        });
+        matchState.addAll({'index': i, 'value': o[i], 'state': state,});
         return false;
       }
     }
@@ -197,8 +198,8 @@ class MatcherList extends Matcher {
     matchers.forEach((m) => m.describe(d));
   }
 
-  Description describeMismatch(item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     if (matchState != null) {
       var index = matchState['index'];
       var value = matchState['value'];
@@ -214,5 +215,4 @@ class MatcherList extends Matcher {
       }
     }
   }
-
 }

--- a/test/visitor_test.dart
+++ b/test/visitor_test.dart
@@ -9,16 +9,13 @@ import 'package:polymer_expressions/visitor.dart';
 import 'package:unittest/unittest.dart';
 
 main() {
-
   group('visitor', () {
-
     // regression test
     test('should not infinitely recurse on parenthesized expressions', () {
       var visitor = new TestVisitor();
       var expr = new Parser('(1)').parse();
       visitor.visit(expr);
     });
-
   });
 }
 


### PR DESCRIPTION
Not sure if the polymer-expressions is into this or not, but this PR `dartfmt`s all the code. Makes it easier to contribute in the future, as my editor auto-formats when I edit Dart files.

All tests still pass (code is functionally equivalent).